### PR TITLE
Fix deprecation warning and Daily.js compatibility issue

### DIFF
--- a/client-react/src/app/api/connect/route.ts
+++ b/client-react/src/app/api/connect/route.ts
@@ -49,8 +49,10 @@ export async function POST(request: NextRequest) {
 
     const data = await response.json();
 
-    // Both local and cloud return the same format
-    return NextResponse.json(data);
+    // Filter out sessionId - Daily.js doesn't accept it
+    const { sessionId, ...dailyConnectionData } = data;
+
+    return NextResponse.json(dailyConnectionData);
   } catch (error) {
     console.error('API error:', error);
     return NextResponse.json(

--- a/server/bot.py
+++ b/server/bot.py
@@ -37,7 +37,7 @@ from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.processors.frameworks.rtvi import RTVIConfig, RTVIObserver, RTVIProcessor
 from pipecat.runner.types import RunnerArguments
-from pipecat.services.cartesia import CartesiaTTSService
+from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport
 from pipecat.transports.services.daily import DailyParams, DailyTransport


### PR DESCRIPTION
This PR fixes two issues that were causing warnings and runtime compatibility problems.

## Changes

### 1. Fixed Cartesia TTS deprecation warning

**Before:**

```python
from pipecat.services.cartesia import CartesiaTTSService
```

**After:**

```python
from pipecat.services.cartesia.tts import CartesiaTTSService
```

The old import path is deprecated. This update removes the deprecation warning and aligns the code with the new module structure.

---

### 2. Filtered out `sessionId` from API response (Daily.js compatibility fix)

**Before:**

```ts
const data = await response.json();
return NextResponse.json(data);
```

When returning the full response directly, the browser console showed the following error while attempting to connect to Daily.js:

```
Failed to join room Error: unrecognized property 'sessionId'
    at daily-esm.js
```

This resulted in the connection failing with:

```
Unable to connect to transport
```

The issue occurs because **Daily.js does not accept `sessionId`** in the connection payload.

**After:**

```ts
const data = await response.json();
// Filter out sessionId - Daily.js doesn't accept it
const { sessionId, ...dailyConnectionData } = data;
return NextResponse.json(dailyConnectionData);
```

By explicitly removing `sessionId` from the response before passing it to Daily.js, the connection error is resolved and the client is able to join the room successfully.
